### PR TITLE
Compositional merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           remote-root: ${{ secrets.ROBOSTAR_WEB_ROOT }}
           remote-baseurl: 'https://robostar.cs.york.ac.uk'
           remote-relative-path: 'robotool/textual/'
-          maven-target: 'circus.robocalc.robochart.generator.textual.repository/target/repository/'
+          maven-target: 'circus.robocalc.robochart.textual.repository/target/repository/'
           
       - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/comp') && github.event_name == 'push'
         name: Create commit comment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,8 @@ jobs:
       #    MAILCHIMPKEY: ${{ secrets.MAILCHIMPKEY }}
       #    MAILCHIMPUSR: ${{ secrets.MAILCHIMPUSR }}
 
-      - name: Rebuild Assertions Plugins
+      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/comp') && github.event_name == 'push'
+        name: Rebuild Assertions Plugins
         run: |
           # Propagate recompilation if global flag is active
           if [[ -z ${ROBOSTAR_RECOMPILE_ALL} || ${ROBOSTAR_RECOMPILE_ALL} = false ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -32,31 +31,45 @@ jobs:
         with:
           java-version: '11'
     
-      - name: Checkout
+      - name: Checkout ${{ github.ref }}
         uses: actions/checkout@master
-        
+
       - name: Build with Maven
         run: mvn clean install
         
-      - name: Setup SSH
-        uses: kielabokkie/ssh-key-and-known-hosts-action@v1
+      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/comp') && github.event_name == 'push'
+        name: Add SSH known hosts
+        run: echo "${ROBOSTAR_WEB_HOST} ${ROBOSTAR_WEB_SSH_FINGERPRINT_TYPE} ${ROBOSTAR_WEB_SSH_FINGERPRINT}" >> ~/.ssh/known_hosts
+        env:
+          ROBOSTAR_WEB_HOST: ${{ secrets.ROBOSTAR_WEB_HOST }}
+          ROBOSTAR_WEB_SSH_FINGERPRINT: ${{ secrets.ROBOSTAR_WEB_SSH_FINGERPRINT }}
+          ROBOSTAR_WEB_SSH_FINGERPRINT_TYPE: ${{ secrets.ROBOSTAR_WEB_SSH_FINGERPRINT_TYPE }}
+        
+      # SSH Setup
+      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/comp') && github.event_name == 'push'
+        name: Setup SSH
+        uses: webfactory/ssh-agent@v0.5.1
         with:
           # Private key required to access the host
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          # Hostname or IP to add to the known hosts file
-          ssh-host: ${{ secrets.ROBOSTAR_WEB_HOST }}
-        
-      - name: Making upload.sh executable
-        run: chmod +x upload.sh
 
-      # If branch is 'master' and not a pull request, then upload.
-      #- if: (github.ref == 'refs/heads/master') && github.event_name != 'pull_request'
-      #  name: Uploading update site
-      #  run: ./upload.sh
-      #  env:
-      #    ROBOSTAR_WEB_ROOT: ${{ secrets.ROBOSTAR_WEB_ROOT }}
-      #    ROBOSTAR_WEB_USER: ${{ secrets.ROBOSTAR_WEB_USER }}
-      #    ROBOSTAR_WEB_HOST: ${{ secrets.ROBOSTAR_WEB_HOST }} 
+      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/comp') && github.event_name == 'push'
+        id: deploy
+        name: Deploy
+        uses: UoY-RoboStar/ga-eclipse-deploy@master
+        with:
+          remote-host: ${{ secrets.ROBOSTAR_WEB_HOST }}
+          remote-user: ${{ secrets.ROBOSTAR_WEB_USER }}
+          remote-root: ${{ secrets.ROBOSTAR_WEB_ROOT }}
+          remote-baseurl: 'https://robostar.cs.york.ac.uk'
+          remote-relative-path: 'robotool/textual/'
+          maven-target: 'circus.robocalc.robochart.generator.textual.repository/target/repository/'
+          
+      - if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/comp') && github.event_name == 'push'
+        name: Create commit comment
+        uses: peter-evans/commit-comment@v1
+        with:
+          body: 'Successfully deployed at: https://robostar.cs.york.ac.uk/robotool/textual/${{ steps.deploy.outputs.dest }}'
       
       # For commits to master other than pull requests, send RoboTool email updates.
       #- if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
@@ -65,7 +78,7 @@ jobs:
       #  env: 
       #    MAILCHIMPKEY: ${{ secrets.MAILCHIMPKEY }}
       #    MAILCHIMPUSR: ${{ secrets.MAILCHIMPUSR }}
-      
+
       - name: Rebuild Assertions Plugins
         run: |
           # Propagate recompilation if global flag is active
@@ -79,8 +92,4 @@ jobs:
           fi
         env:
           ROBOSTAR_RECOMPILE_ALL: ${{ secrets.ROBOSTAR_RECOMPILE_ALL }}
-          ROBOSTAR_GITHUB_ACTIONS_TOKEN: ${{ secrets.ROBOSTAR_GITHUB_ACTIONS_TOKEN }}
-
-      #- name: The job has failed
-      #  if: failure()
-      #  run: rm -rf /tmp/$GITHUB_RUN_NUMBER
+          ROBOSTAR_GITHUB_ACTIONS_TOKEN: ${{ secrets.ROBOSTAR_GITHUB_ACTIONS_TOKEN }} 

--- a/circus.robocalc.robochart.textual.feature/feature.xml
+++ b/circus.robocalc.robochart.textual.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="circus.robocalc.robochart.textual.feature"
       label="RoboChart Textual Editor"
-      version="2.0.0.qualifier"
+      version="3.0.0.qualifier"
       provider-name="RoboCalc Project">
 
    <description url="https://www.cs.york.ac.uk/robostar/robotool/">

--- a/circus.robocalc.robochart.textual.feature/pom.xml
+++ b/circus.robocalc.robochart.textual.feature/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: EPL-2.0
 	<parent>
 		<groupId>circus.robocalc.robochart.textual</groupId>
 		<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>circus.robocalc.robochart.textual.feature</artifactId>
 	<packaging>eclipse-feature</packaging>

--- a/circus.robocalc.robochart.textual.ide/META-INF/MANIFEST.MF
+++ b/circus.robocalc.robochart.textual.ide/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-SymbolicName: circus.robocalc.robochart.textual.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: circus.robocalc.robochart.textual,

--- a/circus.robocalc.robochart.textual.ide/pom.xml
+++ b/circus.robocalc.robochart.textual.ide/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: EPL-2.0
 	<parent>
 		<groupId>circus.robocalc.robochart.textual</groupId>
 		<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>circus.robocalc.robochart.textual.ide</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/circus.robocalc.robochart.textual.repository/pom.xml
+++ b/circus.robocalc.robochart.textual.repository/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: EPL-2.0
 	<parent>
 		<groupId>circus.robocalc.robochart.textual</groupId>
 		<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>circus.robocalc.robochart.textual.repository</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/circus.robocalc.robochart.textual.target/pom.xml
+++ b/circus.robocalc.robochart.textual.target/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: EPL-2.0
 	<parent>
 		<groupId>circus.robocalc.robochart.textual</groupId>
 		<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>circus.robocalc.robochart.textual.target</artifactId>
 	<packaging>eclipse-target-definition</packaging>

--- a/circus.robocalc.robochart.textual.tests/META-INF/MANIFEST.MF
+++ b/circus.robocalc.robochart.textual.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: circus.robocalc.robochart.textual.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-SymbolicName: circus.robocalc.robochart.textual.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: circus.robocalc.robochart.textual,

--- a/circus.robocalc.robochart.textual.tests/pom.xml
+++ b/circus.robocalc.robochart.textual.tests/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: EPL-2.0
 	<parent>
 		<groupId>circus.robocalc.robochart.textual</groupId>
 		<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>circus.robocalc.robochart.textual.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/circus.robocalc.robochart.textual.ui.tests/META-INF/MANIFEST.MF
+++ b/circus.robocalc.robochart.textual.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: circus.robocalc.robochart.textual.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-SymbolicName: circus.robocalc.robochart.textual.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: circus.robocalc.robochart.textual.ui,

--- a/circus.robocalc.robochart.textual.ui.tests/pom.xml
+++ b/circus.robocalc.robochart.textual.ui.tests/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: EPL-2.0
 	<parent>
 		<groupId>circus.robocalc.robochart.textual</groupId>
 		<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>circus.robocalc.robochart.textual.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/circus.robocalc.robochart.textual.ui/META-INF/MANIFEST.MF
+++ b/circus.robocalc.robochart.textual.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-SymbolicName: circus.robocalc.robochart.textual.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: circus.robocalc.robochart.textual,

--- a/circus.robocalc.robochart.textual.ui/pom.xml
+++ b/circus.robocalc.robochart.textual.ui/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: EPL-2.0
 	<parent>
 		<groupId>circus.robocalc.robochart.textual</groupId>
 		<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>circus.robocalc.robochart.textual.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/circus.robocalc.robochart.textual/META-INF/MANIFEST.MF
+++ b/circus.robocalc.robochart.textual/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-SymbolicName: circus.robocalc.robochart.textual;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: circus.robocalc.robochart,

--- a/circus.robocalc.robochart.textual/pom.xml
+++ b/circus.robocalc.robochart.textual/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: EPL-2.0
 	<parent>
 		<groupId>circus.robocalc.robochart.textual</groupId>
 		<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>circus.robocalc.robochart.textual</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -1041,14 +1041,14 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 				/* C4 */
 				// In the new compositional semantics this restriction is no longer required,
 				// as instead, C4 only applies at the level of a controller.
-				val rOps = getROps(s)
-				if (!pOps.containsAll(rOps)) {
-					error(
-						c.name + ' does not provide all operations required by ' + getName(s),
-						RoboChartPackage.Literals.NAMED_ELEMENT__NAME,
-						'ControllerProvidesAllOps'
-					)
-				}
+//				val rOps = getROps(s)
+//				if (!pOps.containsAll(rOps)) {
+//					error(
+//						c.name + ' does not provide all operations required by ' + getName(s),
+//						RoboChartPackage.Literals.NAMED_ELEMENT__NAME,
+//						'ControllerProvidesAllOps'
+//					)
+//				}
 				/* STM9 */
 				val levents = new HashSet<Event>
 				levents.addAll(c.events)
@@ -1145,14 +1145,14 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 					)
 				}
 				/* C4 */
-				val rOps = getROps(s)
-				if (!pOps.containsAll(rOps)) {
-					error(
-						c.name + ' in the context of the controller ' + parent.name + ' does not provide all operations required by ' + getName(s),
-						RoboChartPackage.Literals.NAMED_ELEMENT__NAME,
-						'ControllerProvidesAllOps'
-					)
-				}			
+//				val rOps = getROps(s)
+//				if (!pOps.containsAll(rOps)) {
+//					error(
+//						c.name + ' in the context of the controller ' + parent.name + ' does not provide all operations required by ' + getName(s),
+//						RoboChartPackage.Literals.NAMED_ELEMENT__NAME,
+//						'ControllerProvidesAllOps'
+//					)
+//				}			
 			}
 		}
 	}

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -1479,14 +1479,16 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	@Check
 	def clockExpOnlySupportedComparator(StateClockExp e) {
 		checkClockExpWellTyped(e)
-		clockExpOnlySupported(e)
+		//clockExpOnlySupported(e)
+		// No longer needed in revised form of TE4
 	}
 
 	/* CE2, covers TE4 for since(clock) */
 	@Check
 	def clockExpOnlySupportedComparator(ClockExp e) {
 		checkClockExpWellTyped(e)
-		clockExpOnlySupported(e)
+		//clockExpOnlySupported(e)
+		// No longer needed in revised form of TE4 
 	}
 
 	/* TE4 (helper) */

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: EPL-2.0
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>circus.robocalc.robochart.textual</groupId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<artifactId>circus.robocalc.robochart.textual.parent</artifactId>
 	<packaging>pom</packaging>
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -31,3 +31,4 @@ deploy:
         code: |-
           ./upload.sh
 
+

--- a/wercker.yml
+++ b/wercker.yml
@@ -30,3 +30,4 @@ deploy:
         name: uploading update site
         code: |-
           ./upload.sh
+


### PR DESCRIPTION
This pull request contains changes to the RoboChart validator that implement weaker versions of the WFC with regards to operations. I've bumped the version of the plug-in to 3.0.0, with the intention of making the other update plug-ins require this updated version.

To summarise the changes are as follows:

STM8 A state machine that requires an operation, including a machine that defines another operation, must define or require all variables required by that operation.

STM9 A state machine that requires an operation, including a machine that defines another operation, must define all events defined in that operation.

TSTM1  A state machine that requires an operation, including a machine that defines another operation, must define or require all clocks required in that operation.

We note that a state machine that does not define an operation, but defines the behaviour of a controller, cannot require a clock (see STM7). In this case, if it requires an operation, it must define the clocks required by that operation.

C4 All operations required by the controller’s state machines, including the machines that define operations, must be required or defined by the
controller.

C12 The operations defined in a controller can require only operations that are either defined or required by that controller. 

TE4 The expressions since(C1) or sinceEntry(S1) may only occur in a comparison expression in which the other branch is an expression that does not involve other since(C2) or sinceEntry(S2). 

TODO: After this is merged and the CSP generator is merged into master the manual needs to be updated.