### PR TITLE
Add functions to compute input/output sets accounting for operations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "circus.robocalc.robochart.textual.tests/robochart-tests"]
 	path = circus.robocalc.robochart.textual.tests/robochart-tests
 	url = git@github.com:UoY-RoboStar/robochart-tests.git
+	branch = operation-event-tests

--- a/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
+++ b/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.^extension.ExtendWith
 import circus.robocalc.robochart.RCPackage
 import circus.robocalc.robochart.RoboChartPackage.Literals
+import org.eclipse.emf.ecore.EClass
 
 @ExtendWith(InjectionExtension)
 @InjectWith(RoboChartInjectorProvider)
@@ -313,7 +314,7 @@ class IntegrationTest {
 		val dir = "robochart-tests/operationInput"
 		val file = "operationInput.rct"
 		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
-		TestRoboChartModelError(dir, file, errorMessage)
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
 	}
 
 	@Test
@@ -321,7 +322,7 @@ class IntegrationTest {
 		val dir = "robochart-tests/operationInput"
 		val file = "operationInput.rct"
 		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
-		TestRoboChartModelError(dir, file, errorMessage)
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
 	}
 
 	// This is not ideal as the errors trace back to this function instead of the test that failed.
@@ -369,14 +370,14 @@ class IntegrationTest {
 		return rs
 	}
 	
-	def void TestRoboChartModelError(String dir, String filename, String errorDescription) {
+	def void TestRoboChartModelError(String dir, String filename, EClass element, String errorDescription) {
 		val rs = loadTestFiles(dir)
 		EcoreUtil.resolveAll(rs)
 		System.out.println("")
 		for (r: rs.resources) {
 			val rname = r.URI
 			if (rname.lastSegment !== null && rname.lastSegment.equals(filename)) {
-				r.assertError(Literals.RC_PACKAGE, null, errorDescription)
+				r.assertError(element, null, errorDescription)
 			}
 		}
 		System.out.println("\n")

--- a/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
+++ b/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
@@ -316,12 +316,44 @@ class IntegrationTest {
 		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
 	}
+	
+	@Test
+	def void operationInputOpRefTest() {
+		val dir = "robochart-tests/operationInputOpRef"
+		val file = "operationInputOpRef.rct"
+		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
+	def void operationInputStmRefTest() {
+		val dir = "robochart-tests/operationInputStmRef"
+		val file = "operationInputStmRef.rct"
+		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
 
 	@Test
 	def void operationOutputTest() {
-		val dir = "robochart-tests/operationInput"
-		val file = "operationInput.rct"
-		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
+		val dir = "robochart-tests/operationOutput"
+		val file = "operationOutput.rct"
+		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
+	def void operationOutputOpRefTest() {
+		val dir = "robochart-tests/operationOutputOpRef"
+		val file = "operationOutputOpRef.rct"
+		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
+	def void operationOutputStmRefTest() {
+		val dir = "robochart-tests/operationOutputStmRef"
+		val file = "operationOutputStmRef.rct"
+		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
 	}
 

--- a/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
+++ b/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
@@ -34,6 +34,8 @@ import org.eclipse.xtext.testing.extensions.InjectionExtension
 import org.eclipse.xtext.testing.validation.ValidationTestHelper
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.^extension.ExtendWith
+import circus.robocalc.robochart.RCPackage
+import circus.robocalc.robochart.RoboChartPackage.Literals
 
 @ExtendWith(InjectionExtension)
 @InjectWith(RoboChartInjectorProvider)
@@ -305,6 +307,22 @@ class IntegrationTest {
 		val dir = "robochart-tests/test14"
 		TestRoboChartModel(dir)
 	}
+	
+	@Test
+	def void operationInputTest() {
+		val dir = "robochart-tests/operationInput"
+		val file = "operationInput.rct"
+		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, errorMessage)
+	}
+
+	@Test
+	def void operationOutputTest() {
+		val dir = "robochart-tests/operationInput"
+		val file = "operationInput.rct"
+		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, errorMessage)
+	}
 
 	// This is not ideal as the errors trace back to this function instead of the test that failed.
 	// TODO: check why resolveAll is needed here and why it duplicates the library files (We add them as file:/ and the resolver adds them as platform:/
@@ -349,5 +367,18 @@ class IntegrationTest {
 			}
 		}
 		return rs
+	}
+	
+	def void TestRoboChartModelError(String dir, String filename, String errorDescription) {
+		val rs = loadTestFiles(dir)
+		EcoreUtil.resolveAll(rs)
+		System.out.println("")
+		for (r: rs.resources) {
+			val rname = r.URI
+			if (rname.lastSegment !== null && rname.lastSegment.equals(filename)) {
+				r.assertError(Literals.RC_PACKAGE, null, errorDescription)
+			}
+		}
+		System.out.println("\n")
 	}
 }

--- a/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
+++ b/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
@@ -311,7 +311,7 @@ class IntegrationTest {
 	
 	@Test
 	def void operationInputTest() {
-		val dir = "robochart-tests/operationInput"
+		val dir = "robochart-tests/robochart-fail/operationInput"
 		val file = "operationInput.rct"
 		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
@@ -319,7 +319,7 @@ class IntegrationTest {
 	
 	@Test
 	def void operationInputOpRefTest() {
-		val dir = "robochart-tests/operationInputOpRef"
+		val dir = "robochart-tests/robochart-fail/operationInputOpRef"
 		val file = "operationInputOpRef.rct"
 		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
@@ -327,7 +327,7 @@ class IntegrationTest {
 	
 	@Test
 	def void operationInputStmRefTest() {
-		val dir = "robochart-tests/operationInputStmRef"
+		val dir = "robochart-tests/robochart-fail/operationInputStmRef"
 		val file = "operationInputStmRef.rct"
 		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
@@ -335,7 +335,7 @@ class IntegrationTest {
 
 	@Test
 	def void operationOutputTest() {
-		val dir = "robochart-tests/operationOutput"
+		val dir = "robochart-tests/robochart-fail/operationOutput"
 		val file = "operationOutput.rct"
 		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
@@ -343,7 +343,7 @@ class IntegrationTest {
 	
 	@Test
 	def void operationOutputOpRefTest() {
-		val dir = "robochart-tests/operationOutputOpRef"
+		val dir = "robochart-tests/robochart-fail/operationOutputOpRef"
 		val file = "operationOutputOpRef.rct"
 		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
@@ -351,7 +351,7 @@ class IntegrationTest {
 	
 	@Test
 	def void operationOutputStmRefTest() {
-		val dir = "robochart-tests/operationOutputStmRef"
+		val dir = "robochart-tests/robochart-fail/operationOutputStmRef"
 		val file = "operationOutputStmRef.rct"
 		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -2508,13 +2508,9 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	def checkControllerConnections(ControllerDef ctrl) {
 		var index = 0
 		for (c : ctrl.connections) {
-			System.out.println("Checking connection " + c);
 			if(c.isBidirec) return; // if the connection is bidirectional, then there are no restrictions
 			/* Cn9 */
 			if (c.from !== ctrl && c.from instanceof StateMachine) {
-				System.out.println(c + ": from connection on " + c.efrom.name + " is state machine " + c.from.name);
-				System.out.println(c.from.name + " input set: " + stmInputSetInContext(stmDef(c.from as StateMachine), ctrl));
-				System.out.println("looking for " + c.efrom);
 				if (stmInputSetInContext(stmDef(c.from as StateMachine), ctrl).contains(c.efrom)) {
 					// determine the source of the error more exactly
 					if (ncInputSet(stmDef(c.from as StateMachine)).contains(c.efrom)) {
@@ -2554,9 +2550,6 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 
 			/* Cn8 */
 			if (c.to !== ctrl && c.to instanceof StateMachine) {
-				System.out.println(c + ": to connection on " + c.eto.name + " is state machine " + c.to.name);
-				System.out.println(c.to.name + " output set: " + stmOutputSetInContext(stmDef(c.to as StateMachine), ctrl));
-				System.out.println("looking for " + c.eto);
 				if (stmOutputSetInContext(stmDef(c.to as StateMachine), ctrl).contains(c.eto)) {
 					// determine the source of the error more exactly
 					if (ncOutputSet(stmDef(c.to as StateMachine)).contains(c.eto)) {

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -2362,7 +2362,8 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	}
 		
 	def getAllEvents(StateMachineBody stm) {
-		var events = stm.events
+		var events = new HashSet<Event>()
+		events.addAll(stm.events)
 		for (iface : stm.interfaces) {
 			events.addAll(iface.events)
 		}

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -2316,6 +2316,26 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 			)
 		}
 	}
+	
+	def HashSet<OperationDef> ncRequiredOpDefs(NodeContainer nc, Controller context) {
+		val ncOps = getROps(nc)
+		val ctrlOps = ctrlDef(context).LOperations
+		
+		var opDefSet = new HashSet()
+		for (ncOp : ncOps) {
+			for (ctrlOp : ctrlOps) {
+				if (OpEqual(ncOp, ctrlOp)) {
+					val opDef = if (ctrlOp instanceof OperationRef) ctrlOp.ref else ctrlOp as OperationDef
+					opDefSet.add(opDef)
+				}
+			}
+		}
+		opDefSet
+	}
+	
+	def HashSet<Event> ncOutputSetInContext(NodeContainer nc, Controller context) {
+		var outputs = ncOutputSet()
+	}	
 
 	def HashSet<Event> ncOutputSet(NodeContainer nc) {
 		var outputs = new HashSet<Event>()


### PR DESCRIPTION
This adds functions `stmOutputSetInContext()` and `stmInputSetInContext()` to compute the inputs and outputs of a `StateMachineBody` in the context of its `Controller`, taking into account operations used by the state machine. It also applies them to the checking of Cn8 and Cn9, which resolves #40.

I added some tests to check that Cn8 and Cn9 catch errors correctly in ill-formed models. I realise there is still some debate over where the tests should go, but this branch currently builds against the `operation-event-tests` branch of the `robochart-tests repository`, with the test projects in a separate `robochart-fail` folder since they are projects that should have errors. Let me know if we want a different test structure. The tests are all run by Maven as part of the build process.