### PR TITLE
Fixed issue #56

### DIFF
--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/scoping/RoboChartScopeProvider.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/scoping/RoboChartScopeProvider.xtend
@@ -569,6 +569,14 @@ class RoboChartScopeProvider extends AbstractRoboChartScopeProvider {
 		p
 	}
 
+	def dispatch IScope variablesDeclared(Interface cont, IScope p) {
+		var s = p
+		for (l : cont.variableList) {
+			s = Scopes::scopeFor(l.vars, s)
+		}
+		return s
+	}
+
 	def dispatch IScope variablesDeclared(Context cont, IScope p) {
 		var s = p
 		for (l : cont.variableList) {


### PR DESCRIPTION
This fixes the scope provider issue where constants cannot be used in the initialisation of variables in the same interface.

If this is approved before the matrix/vector pull request, I'll update that to account for this change.