### PR TITLE
Fixes for issues 28, 83 and 84.

### DIFF
--- a/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
+++ b/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
@@ -327,6 +327,26 @@ class IntegrationTest {
 	}
 	
 	@Test
+	def void testRPVarVisible() {
+		val dir = top_dir+"robochart/rp-var-visible"
+		TestRoboChartModel(dir)
+	}
+	
+	@Test
+	def void testRPVarVisibleUses() {
+		val dir = top_dir+"robochart/rp-var-visible-uses"
+		TestRoboChartModel(dir)
+	}
+	
+	@Test
+	def void testCallScopeFail() {
+		val dir = top_dir+"robochart-fail/opcall-scope-fail"
+		val file = "main.rct"
+		val errorMessage = "Couldn't resolve reference to OperationSig 'op'"
+		TestRoboChartModelError(dir, file, Literals.CALL, "org.eclipse.xtext.diagnostics.Diagnostic.Linking", errorMessage)
+	}
+	
+	@Test
 	def void operationInputTest() {
 		val dir = top_dir+"robochart-fail/operationInput"
 		val file = "operationInput.rct"

--- a/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
+++ b/circus.robocalc.robochart.textual.tests/src/circus/robocalc/robochart/textual/tests/IntegrationTest.xtend
@@ -355,6 +355,14 @@ class IntegrationTest {
 	}
 	
 	@Test
+	def void operationInputTestTimed() {
+		val dir = top_dir+"robochart-fail/operationInputTimed"
+		val file = "operationInput.rct"
+		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
 	def void operationInputOpRefTest() {
 		val dir = top_dir+"robochart-fail/operationInputOpRef"
 		val file = "operationInputOpRef.rct"
@@ -363,8 +371,24 @@ class IntegrationTest {
 	}
 	
 	@Test
+	def void operationInputOpRefTestTimed() {
+		val dir = top_dir+"robochart-fail/operationInputOpRefTimed"
+		val file = "operationInputOpRef.rct"
+		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
 	def void operationInputStmRefTest() {
 		val dir = top_dir+"robochart-fail/operationInputStmRef"
+		val file = "operationInputStmRef.rct"
+		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
+	def void operationInputStmRefTestTimed() {
+		val dir = top_dir+"robochart-fail/operationInputStmRefTimed"
 		val file = "operationInputStmRef.rct"
 		val errorMessage = "inputEvent on OperationInputSTM is used as the end of a unidirectional connection, but OperationInputSTM outputs on inputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
@@ -379,6 +403,14 @@ class IntegrationTest {
 	}
 	
 	@Test
+	def void operationOutputTestTimed() {
+		val dir = top_dir+"robochart-fail/operationOutputTimed"
+		val file = "operationOutput.rct"
+		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
 	def void operationOutputOpRefTest() {
 		val dir = top_dir+"robochart-fail/operationOutputOpRef"
 		val file = "operationOutputOpRef.rct"
@@ -387,8 +419,24 @@ class IntegrationTest {
 	}
 	
 	@Test
+	def void operationOutputOpRefTestTimed() {
+		val dir = top_dir+"robochart-fail/operationOutputOpRefTimed"
+		val file = "operationOutputOpRef.rct"
+		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
 	def void operationOutputStmRefTest() {
 		val dir = top_dir+"robochart-fail/operationOutputStmRef"
+		val file = "operationOutputStmRef.rct"
+		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
+		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)
+	}
+	
+	@Test
+	def void operationOutputStmRefTestTimed() {
+		val dir = top_dir+"robochart-fail/operationOutputStmRefTimed"
 		val file = "operationOutputStmRef.rct"
 		val errorMessage = "outputEvent on OperationOutputSTM is used as the start of a unidirectional connection, but OperationOutputSTM receives input on outputEvent via the operation Op"
 		TestRoboChartModelError(dir, file, Literals.CONNECTION, errorMessage)

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/scoping/RoboChartScopeProvider.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/scoping/RoboChartScopeProvider.xtend
@@ -189,7 +189,7 @@ class RoboChartScopeProvider extends AbstractRoboChartScopeProvider {
 		} else if (context instanceof Call) {
 			if (reference === CALL__OPERATION) {
 				//changed the parent scope to avoid accepting OperationDefs being in the scope for Calls
-				val s = delegateGetScope(context, reference) //IScope::NULLSCOPE
+				val s = IScope::NULLSCOPE //delegateGetScope(context, reference) //IScope::NULLSCOPE
 				return context.operationsDeclared(s)
 			}
 		} else if (context instanceof CallExp) {

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -127,6 +127,7 @@ import java.util.ArrayList
 import circus.robocalc.robochart.Clock
 import circus.robocalc.robochart.Communication
 import circus.robocalc.robochart.CommunicationStmt
+import circus.robocalc.robochart.TimedStatement
 
 /**
  * This class contains custom validation rules. 
@@ -2505,6 +2506,8 @@ https://github.com/UoY-RoboStar/robochart-csp-gen/issues/39',
 		} else if (s instanceof IfStmt) {
 			outputs.addAll(statementOutputSet(s.getThen))
 			outputs.addAll(statementOutputSet(s.getElse))
+		} else if (s instanceof TimedStatement) {
+			outputs.addAll(statementOutputSet(s.stmt))
 		}
 
 		outputs
@@ -2584,6 +2587,8 @@ https://github.com/UoY-RoboStar/robochart-csp-gen/issues/39',
 		} else if (s instanceof IfStmt) {
 			inputs.addAll(statementInputSet(s.getThen))
 			inputs.addAll(statementInputSet(s.getElse))
+		} else if (s instanceof TimedStatement) {
+			inputs.addAll(statementInputSet(s.stmt))
 		}
 
 		inputs

--- a/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
+++ b/circus.robocalc.robochart.textual/src/circus/robocalc/robochart/textual/validation/RoboChartValidator.xtend
@@ -651,26 +651,25 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	@Check
 	def roboticPlatformWFC(RoboticPlatformDef rp) {
 		/* RP1 */
-		for (i : rp.RInterfaces) {
+		for (var it = rp.RInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+			
 			error(
 				rp.name + ' is a robotic platform and cannot require interface ' + i.name,
-				RoboChartPackage.Literals.CONTEXT__RINTERFACES,
+				RoboChartPackage.Literals.CONTEXT__RINTERFACES, index,
 				'RPNoRequiredInterfaces'
 			)
 		}
 		/* RP2 */
-		for (Interface i : rp.interfaces) {
-			if (i.variableList.size > 0)
-				error(
-					getName(rp) + ' cannot define interface ' + i.name + ' because it contains variables',
-					RoboChartPackage.Literals.CONTEXT__INTERFACES,
-					'UsedInterfaceWithOnlyEvents'
-				)
+		for (var it = rp.interfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
 				
 			if (i.clocks.size > 0)
 				error(
 					getName(rp) + ' cannot define interface ' + i.name + ' because it contains clocks',
-					RoboChartPackage.Literals.CONTEXT__INTERFACES,
+					RoboChartPackage.Literals.CONTEXT__INTERFACES, index,
 					'UsedInterfaceWithOnlyEvents'
 				)
 		}
@@ -688,10 +687,14 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	@Check
 	/* O1:STM1 */
 	def operationDefWFC(OperationDef o) {
-		for (i : o.PInterfaces) {
+		
+		for (var it = o.PInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+		
 			error(
 				o.name + ' is an operation definition and cannot provide interface ' + i.name,
-				RoboChartPackage.Literals.CONTEXT__PINTERFACES,
+				RoboChartPackage.Literals.CONTEXT__PINTERFACES, index,
 				'OperationNoProvidedInterfaces'
 			)
 		}
@@ -700,22 +703,28 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	@Check
 	def requiredWFC(Context c) {
 		/* I1 */
-		for (i : c.RInterfaces) {
+		for (var it = c.RInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+						
 			if (i.events.size > 0) {
 				error(
 					getName(c) + ' cannot require interface ' + i.name + ' because it contains events',
-					RoboChartPackage.Literals.CONTEXT__INTERFACES,
+					RoboChartPackage.Literals.CONTEXT__RINTERFACES, index,
 					'RequiredInterfaceWithEvents'
 				)
 			}
 		}
 
 		/* I1 */
-		for (i : c.PInterfaces) {
+		for (var it = c.PInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+			
 			if (i.events.size > 0) {
 				error(
 					getName(c) + ' cannot provide interface ' + i.name + ' because it contains events',
-					RoboChartPackage.Literals.CONTEXT__INTERFACES,
+					RoboChartPackage.Literals.CONTEXT__PINTERFACES, index,
 					'ProvidedInterfaceWithEvents'
 				)
 			}
@@ -723,18 +732,21 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 			if (i.clocks.size > 0) {
 				error(
 					getName(c) + ' cannot provide interface ' + i.name + ' because it contains clocks',
-					RoboChartPackage.Literals.CONTEXT__INTERFACES,
+					RoboChartPackage.Literals.CONTEXT__PINTERFACES, index,
 					'ProvidedInterfaceWithClocks'
 				)
 			}
 		}
 
 		/* I2, together with I2 implies STM2 and (because OperationDef is a Context) O1:STM2 */
-		for (Interface i : c.interfaces) {
+		for (var it = c.interfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+			
 			if (i.operations.size > 0)
 				error(
 					getName(c) + ' cannot define interface ' + i.name + ' because it contains operations',
-					RoboChartPackage.Literals.CONTEXT__INTERFACES,
+					RoboChartPackage.Literals.CONTEXT__INTERFACES, index,
 					'UsedInterfaceWithOnlyEvents'
 				)
 		}
@@ -760,10 +772,13 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 		
 		
 		/* C2 */
-		for (i : c.PInterfaces) {
+		for (var it = c.PInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+			
 			error(
 				c.name + ' is a controller and cannot provide interface ' + i.name,
-				RoboChartPackage.Literals.CONTEXT__PINTERFACES,
+				RoboChartPackage.Literals.CONTEXT__PINTERFACES, index,
 				'ControllerNoRequiredInterfaces'
 			)
 		}
@@ -905,21 +920,27 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 		}
 		
 		/* C10 */
-		for (i : c.interfaces) {
+		for (var it = c.interfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+			
 			if (i.clocks.size > 0)
 				error(
 					c.name + ' is a controller and cannot define interface ' + i.name + ' because it contains clocks',
-					RoboChartPackage.Literals.CONTEXT__INTERFACES,
+					RoboChartPackage.Literals.CONTEXT__INTERFACES, index,
 					'ControllerNoDefinedInterfacesWithClocks'
 				)
 		}
 		
 		/* C11 */
-		for (i : c.RInterfaces) {
+		for (var it = c.RInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+
 			if (i.clocks.size > 0)
 				error(
 					c.name + ' is a controller and cannot require interface ' + i.name + ' because it contains clocks',
-					RoboChartPackage.Literals.CONTEXT__RINTERFACES,
+					RoboChartPackage.Literals.CONTEXT__RINTERFACES, index,
 					'ControllerNoRequiredInterfacesWithClocks'
 				)
 		}
@@ -1029,10 +1050,14 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	/* STM1, together with I2 implies STM2 and (because OperationDef is a Context) O1:STM2 */
 	@Check
 	def stmWFC(StateMachineDef c) {
-		for (i : c.PInterfaces) {
+		
+		for (var it = c.PInterfaces.listIterator; it.hasNext; ) {		
+			var index = it.nextIndex
+			var i = it.next
+
 			error(
 				c.name + ' is a state machine and cannot provide interface ' + i.name,
-				RoboChartPackage.Literals.CONTEXT__PINTERFACES,
+				RoboChartPackage.Literals.CONTEXT__PINTERFACES, index,
 				'StateMachineNoProvidedInterfaces'
 			)
 		}
@@ -1130,11 +1155,14 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 		}
 		
 		/* STM7 */
-		for (i : c.RInterfaces) {
+		for (var it = c.RInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+		
 			if (i.clocks.size > 0)
 				error(
 					c.name + ' is a state machine and cannot require interface ' + i.name + ' because it contains clocks',
-					RoboChartPackage.Literals.CONTEXT__RINTERFACES,
+					RoboChartPackage.Literals.CONTEXT__RINTERFACES, index,
 					'StateMachineNoRequiredInterfacesWithClocks'
 				)
 		}
@@ -1423,19 +1451,26 @@ class RoboChartValidator extends AbstractRoboChartValidator {
 	/* I1 */
 	@Check
 	def interfaceEitherEventsOrOthers(Context d) {
-		for (Interface i : d.RInterfaces) {
+		
+		for (var it = d.RInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+		
 			if (i.events.size > 0)
 				error(
 					getName(d) + ' cannot require interface ' + i.name + ' because it contains events',
-					RoboChartPackage.Literals.CONTEXT__RINTERFACES,
+					RoboChartPackage.Literals.CONTEXT__RINTERFACES, index,
 					'RequiredInterfaceWithoutEvents'
 				)
 		}
-		for (Interface i : d.PInterfaces) {
+		for (var it = d.PInterfaces.listIterator; it.hasNext; ) {
+			var index = it.nextIndex
+			var i = it.next
+		
 			if (i.events.size > 0)
 				error(
 					getName(d) + ' cannot provide interface ' + i.name + ' because it contains events',
-					RoboChartPackage.Literals.CONTEXT__PINTERFACES,
+					RoboChartPackage.Literals.CONTEXT__PINTERFACES, index,
 					'ProvidedInterfaceWithoutEvents'
 				)
 		}


### PR DESCRIPTION
This pull request includes changes that fixes #28, fixes #83 and fixes #84. I've also added test cases that exercise these issues.

In addressing some of these issues I've taken the liberty to improve error reporting by using the 'index' from iterators in the validator. For example, if the second used interface of a machine violates one of the WFCs, often the validator would visually flag this on the first one, rather than the second. That is now annotated appropriately.